### PR TITLE
manually set new DirectMessageChannel

### DIFF
--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -254,6 +254,15 @@ class RealTimeClient extends ApiClient
 
         return Promise\resolve($this->dms[$id]);
     }
+    
+    /**
+     * Set new DM
+     * @param DirectMessageChannel $dm
+     */
+    public function setDM(DirectMessageChannel $dm)
+    {
+        $this->dms[ $dm->getId() ] = $dm;
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Usefull when in client code you first need to call 'im.open' and then send message to this newly created DM. Since this new DM does not exists in $this->dms at that moment sending message to that channel will fail.