### PR TITLE
catch and log payload handling errors

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -3,6 +3,8 @@ namespace Slack;
 
 use GuzzleHttp;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use Slack\Message\Message;
@@ -34,15 +36,25 @@ class ApiClient
     protected $loop;
 
     /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
      * Creates a new API client instance.
      *
-     * @param GuzzleHttp\ClientInterface $httpClient A Guzzle client instance to
-     *                                               send requests with.
+     * @param LoopInterface $loop
+     * @param GuzzleHttp\ClientInterface $httpClient A Guzzle client instance to send requests with.
+     * @param LoggerInterface $logger
      */
-    public function __construct(LoopInterface $loop, GuzzleHttp\ClientInterface $httpClient = null)
+    public function __construct(
+        LoopInterface $loop,
+        GuzzleHttp\ClientInterface $httpClient = null,
+        LoggerInterface $logger = null)
     {
         $this->loop = $loop;
         $this->httpClient = $httpClient ?: new GuzzleHttp\Client();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -12,11 +12,11 @@ class Payload implements \ArrayAccess, \JsonSerializable
     protected $data;
 
     /**
-     * Creates a response object from a JSON message.
+     * Creates a payload object from a JSON message.
      *
      * @param string $json A JSON string.
      *
-     * @return Response The parsed response.
+     * @return Payload The parsed message.
      */
     public static function fromJson($json)
     {

--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -6,6 +6,7 @@ use Devristo\Phpws\Messaging\WebSocketMessageInterface;
 use Evenement\EventEmitterTrait;
 use React\Promise;
 use Slack\Message\Message;
+use Throwable;
 
 /**
  * A client for the Slack real-time messaging API.
@@ -361,13 +362,23 @@ class RealTimeClient extends ApiClient
     /**
      * Handles incoming websocket messages, parses them, and emits them as remote events.
      *
-     * @param WebSocketMessageInterface $messageRaw A websocket message.
+     * @param WebSocketMessageInterface $message A websocket message.
      */
     private function onMessage(WebSocketMessageInterface $message)
     {
-        // parse the message and get the event name
         $payload = Payload::fromJson($message->getData());
 
+        try {
+            $this->handlePayload($payload);
+        } catch (Throwable $throwable) {
+            $this->logger->warning('Payload handling error: '.$throwable->getMessage());
+            $this->logger->warning('Payload: '.$payload->toJson());
+            $this->logger->warning($throwable->getTraceAsString());
+        }
+    }
+
+    private function handlePayload(Payload $payload)
+    {
         if (isset($payload['type'])) {
             switch ($payload['type']) {
                 case 'hello':

--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -370,10 +370,12 @@ class RealTimeClient extends ApiClient
 
         try {
             $this->handlePayload($payload);
-        } catch (Exception $throwable) {
-            $this->logger->warning('Payload handling error: '.$throwable->getMessage());
-            $this->logger->warning('Payload: '.$payload->toJson());
-            $this->logger->warning($throwable->getTraceAsString());
+        } catch (Exception $exception) {
+            $context = [
+                'payload' => $message->getData(),
+                'stackTrace' => $exception->getTrace(),
+            ];
+            $this->logger->error('Payload handling error: '.$exception->getMessage(), $context);
         }
     }
 

--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -4,9 +4,9 @@ namespace Slack;
 use Devristo\Phpws\Client\WebSocket;
 use Devristo\Phpws\Messaging\WebSocketMessageInterface;
 use Evenement\EventEmitterTrait;
+use Exception;
 use React\Promise;
 use Slack\Message\Message;
-use Throwable;
 
 /**
  * A client for the Slack real-time messaging API.
@@ -370,7 +370,7 @@ class RealTimeClient extends ApiClient
 
         try {
             $this->handlePayload($payload);
-        } catch (Throwable $throwable) {
+        } catch (Exception $throwable) {
             $this->logger->warning('Payload handling error: '.$throwable->getMessage());
             $this->logger->warning('Payload: '.$payload->toJson());
             $this->logger->warning($throwable->getTraceAsString());


### PR DESCRIPTION
It doesn't look like you are maintaining slack-client any longer, but my bot receives killer channel_archive messages from Slack, I haven't caught the message itself, but here is the result:

PHP Fatal error:  Uncaught ErrorException: Illegal string offset 'id' in /home/kip/php-kip/vendor/coderstephen/slack-client/src/RealTimeClient.php:406

This PR attempts to ameliorate by catching and logging errors thrown while handling payloads.