### PR TITLE
channel_delete/(un)archive event passes the channel as id only

### DIFF
--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -394,7 +394,7 @@ class RealTimeClient extends ApiClient
                     break;
 
                 case 'channel_deleted':
-                    unset($this->channels[$payload['channel']['id']]);
+                    unset($this->channels[$payload['channel']]);
                     break;
 
                 case 'channel_rename':
@@ -403,11 +403,11 @@ class RealTimeClient extends ApiClient
                     break;
 
                 case 'channel_archive':
-                    $this->channels[$payload['channel']['id']]->data['is_archived'] = true;
+                    $this->channels[$payload['channel']]->data['is_archived'] = true;
                     break;
 
                 case 'channel_unarchive':
-                    $this->channels[$payload['channel']['id']]->data['is_archived'] = false;
+                    $this->channels[$payload['channel']]->data['is_archived'] = false;
                     break;
 
                 case 'group_joined':


### PR DESCRIPTION
not the entire channel object (id, name, ..)